### PR TITLE
Added tinkertanker to approved organisations

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -3,7 +3,8 @@
         "approvedOrgs": [
             "Microsoft",
             "microbit-foundation",
-            "KitronikLtd"
+            "KitronikLtd",
+            "tinkertanker"
         ],
         "approvedRepos": [
             "CoderDojoOlney/pxt-olney",
@@ -13,7 +14,6 @@
             "sparkfun/pxt-gamer-bit",
             "sparkfun/pxt-moto-bit",
             "sparkfun/pxt-weather-bit",
-            "Tinkertanker/pxt-ssd1306-microbit",
             "minodekit/pxt-minode",
             "LaboratoryForPlayfulComputation/pxt-BlockyTalkyBLE"
         ],


### PR DESCRIPTION
Tinkertanker work closely with the foundation and have a number of packages, and they understand the requirements for alpha/beta release quality so we're adding them as an approved org.

Removed "Tinkertanker/pxt-ssd1306-microbit", as his is covered by approved org status